### PR TITLE
Squawk action can handle globbing of files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ runs:
         export SQUAWK_GITHUB_REPO_OWNER=$(jq --raw-output .repository.owner.login "$GITHUB_EVENT_PATH")
         export SQUAWK_GITHUB_REPO_NAME=$(jq --raw-output .repository.name "$GITHUB_EVENT_PATH")
         export SQUAWK_GITHUB_PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-        squawk --verbose upload-to-github $(compgen -G ${{inputs.pattern}})
+        squawk --verbose upload-to-github $(compgen -G "${{inputs.pattern}}")
       shell: bash


### PR DESCRIPTION
When a glob is passed that targets multiple files, bash is expanding the wildcard before compgen is run, resulting in only one file getting passed to squawk. Quoting prevents bash from trying to expand the glob early.

For example, from the project root:
```
> compgen -G ./*.md                     
./CHANGELOG.md
```
and now with quoting
```
> compgen -G "./*.md"
./CHANGELOG.md
./README.md
```

This should fix https://github.com/sbdchd/squawk-action/issues/4
