### PR TITLE
Allow passing of multiple file paths

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,18 +16,31 @@ inputs:
     required: true
   pattern:
     description: "Glob pattern of files to match. (./migrations/*)"
-    required: true
-
+    required: false
+    default: ''
+  files:
+    description: "Space separated list of file paths to check. Cannot contain glob patterns."
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
     - uses: actions/setup-node@v3
     - run: npm install -g squawk-cli@${{inputs.version}}
       shell: bash
-    - run: |
+    - if: inputs.pattern != ''
+      run: |
         export SQUAWK_GITHUB_TOKEN=${{inputs.access_token}}
         export SQUAWK_GITHUB_REPO_OWNER=$(jq --raw-output .repository.owner.login "$GITHUB_EVENT_PATH")
         export SQUAWK_GITHUB_REPO_NAME=$(jq --raw-output .repository.name "$GITHUB_EVENT_PATH")
         export SQUAWK_GITHUB_PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         squawk --verbose upload-to-github $(compgen -G "${{inputs.pattern}}")
+      shell: bash
+    - if: inputs.files != ''
+      run: |
+        export SQUAWK_GITHUB_TOKEN=${{inputs.access_token}}
+        export SQUAWK_GITHUB_REPO_OWNER=$(jq --raw-output .repository.owner.login "$GITHUB_EVENT_PATH")
+        export SQUAWK_GITHUB_REPO_NAME=$(jq --raw-output .repository.name "$GITHUB_EVENT_PATH")
+        export SQUAWK_GITHUB_PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        squawk --verbose upload-to-github ${{inputs.files}}
       shell: bash


### PR DESCRIPTION
Due to compgen omitting all but the first passed path, introducing another input variable to run Squawk on multiple files and/or glob patterns.

Should fix https://github.com/sbdchd/squawk-action/issues/9