### PR TITLE
Use dependabot & latest node version as 16 is deprecated

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: 'daily'

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
     - run: npm install -g squawk-cli@${{inputs.version}}
       shell: bash
     - if: inputs.pattern != ''


### PR DESCRIPTION
Small PR to introduce dependabot and to update the node action to use the latest node version. Otherwise, the CI will always show this warning

> lint_migrations
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

![grafik](https://github.com/sbdchd/squawk-action/assets/2665370/fe098cbd-4420-42fc-a349-45cde6832b71)
