### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ jobs:
   lint_migrations:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Find modified migrations
         run: |
           modified_migrations=$(git diff --diff-filter=d --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF 'migrations/*.sql')


### PR DESCRIPTION
The advanced example was not updated in #19, and needs to use `fetch-depth` in order to be working with `actions/checkout` past `v1`. See https://github.com/actions/checkout/blob/main/CHANGELOG.md#v2-beta