### PR TITLE
Update README to use GITHUB_OUTPUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ jobs:
         run: |
           modified_migrations=$(git diff --diff-filter=d --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF 'migrations/*.sql')
           echo "$modified_migrations"
-          echo "::set-output name=file_names::$modified_migrations"
+          echo "file_names=$modified_migrations" >> $GITHUB_OUTPUT
         id: modified-migrations
       - uses: sbdchd/squawk-action@v2
         with:
-          pattern: ${{ steps.modified-migrations.outputs.file_names }}
+          files: ${{ steps.modified-migrations.outputs.file_names }}
 ```
 
 > [!TIP]


### PR DESCRIPTION
Github has started warning on use of ::set-output and is slowly moving towards
deprecating its usage. This gets people to use the new $GITHUB_OUTPUT instead.

This also updates the example to use :files, since $modified_files will be a
list of filenames, not regexps, and AFAICT this doesn't trigger when used this
way.
