### PR TITLE
feat: allow passing a config file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,11 @@ inputs:
     required: false
     default: "false"
     type: boolean
+  config:
+    description: "Path to a custom config file"
+    required: false
+    default: ""
+    type: string
   exclude:
     description: "Rules to exclude, as a comma-separated string"
     required: false
@@ -60,6 +65,7 @@ runs:
     - shell: bash
       run: |
         ASSUME_IN_TRANSACTION="${{ inputs.assume-in-transaction }}"
+        CONFIG="${{ inputs.config }}"
         EXCLUDE="${{ inputs.exclude }}"
         FAIL_ON_VIOLATIONS="${{ inputs.fail-on-violations }}"
         FILES="${{ inputs.files }}"
@@ -71,6 +77,10 @@ runs:
 
         if "$ASSUME_IN_TRANSACTION"; then
           COMMAND="$COMMAND --assume-in-transaction"
+        fi
+
+        if [ -n "$CONFIG" ]; then
+          COMMAND="$COMMAND --config=$CONFIG"
         fi
 
         if [ -n "$EXCLUDE" ]; then


### PR DESCRIPTION
Allow explicitly passing a config file to the `squawk` command. Technically (per #6) it'll pull the config, but only if it's in the root directory, which is problematic for monorepos.

Fixes #26